### PR TITLE
Makefile.in: Remove win32/prj/GNUmakefile from EXTRA_DIST

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -385,7 +385,6 @@ EXTRA_DIST = \
 	smbutil.c \
 	stime.awk \
 	tcpdump.1.in \
-	win32/prj/GNUmakefile \
 	win32/prj/WinDump.dsp \
 	win32/prj/WinDump.dsw \
 	win32/prj/WinDump.sln \


### PR DESCRIPTION
File removed in commit 1d77715d2e2246f2a155acad248c55ac9c458b68.

[skip ci]